### PR TITLE
fix:远程调用不能调用实现里面的私有方法

### DIFF
--- a/src/main/groovy/org/nofdev/servicefacade/BatchController.groovy
+++ b/src/main/groovy/org/nofdev/servicefacade/BatchController.groovy
@@ -61,7 +61,7 @@ class BatchController {
                 throw new BatchException();
             }
 
-            Method[] methods = ReflectionUtils.getAllDeclaredMethods(interfaceClazz);
+            Method[] methods = interfaceClazz.getMethods();
             Method method = null;
             for (Method m : methods) {
                 if (methodName.equals(m.getName())) {

--- a/src/main/groovy/org/nofdev/servicefacade/FacadeController.groovy
+++ b/src/main/groovy/org/nofdev/servicefacade/FacadeController.groovy
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*
 
 import java.lang.reflect.Method
 import java.lang.reflect.Type
+
 /**
  * Created by wangxuesong on 15/8/14.
  */
@@ -65,7 +66,7 @@ public class FacadeController {
                 throw new ServiceNotFoundException();
             }
 
-            Method[] methods = ReflectionUtils.getAllDeclaredMethods(interfaceClazz);
+            Method[] methods = interfaceClazz.getMethods();
             Method method = null;
             for (Method m : methods) {
                 if (methodName.equals(m.getName())) {

--- a/src/main/groovy/org/nofdev/servicefacade/ServiceController.groovy
+++ b/src/main/groovy/org/nofdev/servicefacade/ServiceController.groovy
@@ -65,7 +65,7 @@ public class ServiceController {
                 throw new ServiceNotFoundException();
             }
 
-            Method[] methods = ReflectionUtils.getAllDeclaredMethods(interfaceClazz);
+            Method[] methods = interfaceClazz.getMethods();
             Method method = null;
             for (Method m : methods) {
                 if (methodName.equals(m.getName())) {


### PR DESCRIPTION
如果有人知道实现里面私有方法的名字就可以通过RPC框架远程执行该方法，这是非常危险的。
为了防止这种事情的发生，只允许调用接口里面定义的public方法
